### PR TITLE
fix CDA endpoint subdomain

### DIFF
--- a/contentful_test.go
+++ b/contentful_test.go
@@ -153,7 +153,7 @@ func TestContentfulNewCDA(t *testing.T) {
 
 	cda := NewCDA(CDAToken)
 	assert.IsType(Contentful{}, *cda)
-	assert.Equal("https://cda.contentful.com", cda.BaseURL)
+	assert.Equal("https://cdn.contentful.com", cda.BaseURL)
 	assert.Equal("CDA", cda.api)
 	assert.Equal(CDAToken, cda.token)
 	assert.Equal(fmt.Sprintf("Bearer %s", CDAToken), cda.Headers["Authorization"])


### PR DESCRIPTION
`contentful.NewCDA` panics with an "invalid endpoint" error as it's pinging `cda.contentful.com` -- however the API documentation points to `cdn.contentful.com`. 

https://www.contentful.com/developers/docs/references/content-delivery-api/