### PR TITLE
New content types can specify their ID.

### DIFF
--- a/content_type.go
+++ b/content_type.go
@@ -330,7 +330,7 @@ func (service *ContentTypesService) Upsert(spaceID string, ct *ContentType) erro
 	var path string
 	var method string
 
-	if ct.Sys != nil && ct.Sys.CreatedAt != "" {
+	if ct.Sys != nil && ct.Sys.ID != "" {
 		path = fmt.Sprintf("/spaces/%s/content_types/%s", spaceID, ct.Sys.ID)
 		method = "PUT"
 	} else {

--- a/content_type_test.go
+++ b/content_type_test.go
@@ -387,6 +387,70 @@ func TestContentTypeSaveForUpdate(t *testing.T) {
 	assert.Equal(2, ct.Sys.Version)
 }
 
+func TestContentTypeCreateWithoutID(t *testing.T) {
+	var err error
+	assert := assert.New(t)
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(r.Method, "POST")
+		assert.Equal(r.RequestURI, "/spaces/id1/content_types")
+		checkHeaders(r, assert)
+
+		w.WriteHeader(200)
+		fmt.Fprintln(w, string(readTestData("content_type-updated.json")))
+	})
+
+	// test server
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	// cma client
+	cma = NewCMA(CMAToken)
+	cma.BaseURL = server.URL
+
+	// test content type
+	ct := &ContentType{
+		Sys:  &Sys{},
+		Name: "MyContentType",
+	}
+
+	cma.ContentTypes.Upsert("id1", ct)
+	assert.Nil(err)
+}
+
+func TestContentTypeCreateWithID(t *testing.T) {
+	var err error
+	assert := assert.New(t)
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(r.Method, "PUT")
+		assert.Equal(r.RequestURI, "/spaces/id1/content_types/mycontenttype")
+		checkHeaders(r, assert)
+
+		w.WriteHeader(200)
+		fmt.Fprintln(w, string(readTestData("content_type-updated.json")))
+	})
+
+	// test server
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	// cma client
+	cma = NewCMA(CMAToken)
+	cma.BaseURL = server.URL
+
+	// test content type
+	ct := &ContentType{
+		Sys: &Sys{
+			ID: "mycontenttype",
+		},
+		Name: "MyContentType",
+	}
+
+	cma.ContentTypes.Upsert("id1", ct)
+	assert.Nil(err)
+}
+
 func TestContentTypeDelete(t *testing.T) {
 	var err error
 	assert := assert.New(t)


### PR DESCRIPTION
It seems that the code only creates a content type with a specified ID if the `CreatedAt` field is not empty, which doesn't make any sense and doesn't seem to agree with the documentation.

Now, we ensure the ID field of the Sys structure is non-empty, and if so create a content type with the specified ID. There are also a couple of basic tests to ensure the correct HTTP methods are used.