### PR TITLE
Add Go Modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/contentful-labs/contentful-go
+
+go 1.12
+
+require (
+	github.com/davecgh/go-spew v1.1.0
+	github.com/moul/http2curl v1.0.0
+	github.com/pmezard/go-difflib v1.0.0
+	github.com/stretchr/testify v1.1.4
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,5 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/moul/http2curl v1.0.0 h1:dRMWoAtb+ePxMlLkrCbAqh4TlPHXvoGUSQ323/9Zahs=
+github.com/moul/http2curl v1.0.0/go.mod h1:8UbvGypXm98wA/IqH45anm5Y2Z6ep6O31QGOAZ3H0fQ=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.1.4/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=


### PR DESCRIPTION
This PR introduces the new Go Modules package management system, it won't delete Gopkg.* since people can continue to use dep until Modules is on by default