### PR TITLE
Allowing the HTTP client to be set by the consumer. 

### DIFF
--- a/contentful.go
+++ b/contentful.go
@@ -120,6 +120,11 @@ func (c *Contentful) SetOrganization(organizationID string) *Contentful {
 	return c
 }
 
+// SetHTTPClient sets the underlying http.Client used to make requests.
+func (c *Contentful) SetHTTPClient(client *http.Client) {
+	c.client = client
+}
+
 func (c *Contentful) newRequest(method, path string, query url.Values, body io.Reader) (*http.Request, error) {
 	u, err := url.Parse(c.BaseURL)
 	if err != nil {

--- a/contentful_test.go
+++ b/contentful_test.go
@@ -179,6 +179,15 @@ func TestContentfulSetOrganization(t *testing.T) {
 	assert.Equal(organizationID, cma.Headers["X-Contentful-Organization"])
 }
 
+func TestContentfulSetClient(t *testing.T) {
+	assert := assert.New(t)
+
+	newClient := &http.Client{}
+	cma := NewCMA(CMAToken)
+	cma.SetHTTPClient(newClient)
+	assert.Equal(newClient, cma.client)
+}
+
 func TestNewRequest(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
Useful for testing or implementing more robust HTTP clients. Fixes issue #37 