### PR TITLE
Fix pagination

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -43,7 +43,7 @@ func NewCollection(options *CollectionOptions) *Collection {
 // Next makes the col.req
 func (col *Collection) Next() (*Collection, error) {
 	// setup query params
-	skip := col.Query.limit * (col.page - 1)
+	skip := uint16(col.Limit) * (col.page - 1)
 	col.Query.Skip(skip)
 
 	// override request query

--- a/testdata/spaces-page-2.json
+++ b/testdata/spaces-page-2.json
@@ -1,0 +1,9 @@
+{
+  "sys": {
+    "type": "Array"
+  },
+  "skip": 0,
+  "limit": 100,
+  "total": 2,
+  "items": []
+}


### PR DESCRIPTION
The calculation for skip was always checking the query limit, which is always 0 and never updated. This means that calling `.Next()` always returns the first page of results. This fixes it to check `Collection.Limit` instead, which will be automatically updated from the http response