### PR TITLE
Correcting the PublishedBy and UpdatedBy fields to include the sys object.

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -162,7 +162,7 @@ func (service *EntriesService) Publish(spaceID string, entry *Entry) error {
 
 // Unpublish the entry
 func (service *EntriesService) Unpublish(spaceID string, entry *Entry) error {
-	path := fmt.Sprintf("/spaces/%s/entries/%s/published", spaceID, entry.Sys.ID)
+	path := fmt.Sprintf("/spaces/%s/environments/%s/entries/%s/published", spaceID, service.c.Environment, entry.Sys.ID)
 	method := "DELETE"
 
 	req, err := service.c.newRequest(method, path, nil, nil)

--- a/entry.go
+++ b/entry.go
@@ -75,7 +75,7 @@ func (service *EntriesService) List(spaceID string) *Collection {
 
 // Get returns a single entry
 func (service *EntriesService) Get(spaceID, entryID string) (*Entry, error) {
-	path := fmt.Sprintf("/spaces/%s/entries/%s", spaceID, entryID)
+	path := fmt.Sprintf("/spaces/%s/environments/%s/entries/%s", spaceID, service.c.Environment, entryID)
 	query := url.Values{}
 	method := "GET"
 
@@ -133,7 +133,7 @@ func (service *EntriesService) Upsert(spaceID string, entry *Entry) error {
 
 // Delete the entry
 func (service *EntriesService) Delete(spaceID string, entryID string) error {
-	path := fmt.Sprintf("/spaces/%s/entries/%s", spaceID, entryID)
+	path := fmt.Sprintf("/spaces/%s/entries/%s/environments/%s", spaceID, service.c.Environment, entryID)
 	method := "DELETE"
 
 	req, err := service.c.newRequest(method, path, nil, nil)
@@ -146,7 +146,7 @@ func (service *EntriesService) Delete(spaceID string, entryID string) error {
 
 // Publish the entry
 func (service *EntriesService) Publish(spaceID string, entry *Entry) error {
-	path := fmt.Sprintf("/spaces/%s/entries/%s/published", spaceID, entry.Sys.ID)
+	path := fmt.Sprintf("/spaces/%s/environments/%s/entries/%s/published", spaceID, service.c.Environment, entry.Sys.ID)
 	method := "PUT"
 
 	req, err := service.c.newRequest(method, path, nil, nil)

--- a/entry.go
+++ b/entry.go
@@ -133,7 +133,7 @@ func (service *EntriesService) Upsert(spaceID string, entry *Entry) error {
 
 // Delete the entry
 func (service *EntriesService) Delete(spaceID string, entryID string) error {
-	path := fmt.Sprintf("/spaces/%s/entries/%s/environments/%s", spaceID, service.c.Environment, entryID)
+	path := fmt.Sprintf("/spaces/%s/environments/%s/entries//%s", spaceID, service.c.Environment, entryID)
 	method := "DELETE"
 
 	req, err := service.c.newRequest(method, path, nil, nil)

--- a/types.go
+++ b/types.go
@@ -7,7 +7,9 @@ type Sys struct {
 	LinkType         string       `json:"linkType,omitempty"`
 	CreatedAt        string       `json:"createdAt,omitempty"`
 	UpdatedAt        string       `json:"updatedAt,omitempty"`
-	UpdatedBy        *Sys         `json:"updatedBy,omitempty"`
+	UpdatedBy        struct{
+		           *Sys         `json:"sys,omitempty"`
+	} `json:"updatedBy,omitempty"`
 	Version          int          `json:"version,omitempty"`
 	Revision         int          `json:"revision,omitempty"`
 	ContentType      *ContentType `json:"contentType,omitempty"`
@@ -15,6 +17,8 @@ type Sys struct {
 	FirstPublishedAt string       `json:"firstPublishedAt,omitempty"`
 	PublishedCounter int          `json:"publishedCounter,omitempty"`
 	PublishedAt      string       `json:"publishedAt,omitempty"`
-	PublishedBy      *Sys         `json:"publishedBy,omitempty"`
+	PublishedBy      struct {
+		*Sys         `json:"sys,omitempty"`
+	} `json:"publishedBy,omitempty"`
 	PublishedVersion int          `json:"publishedVersion,omitempty"`
 }


### PR DESCRIPTION
The API returns a Sys object for the `publishedBy` and `updatedBy` fields. This PR fixes that issue by restructuring the types. 