### PR TITLE
Allow retrieving locaized assets

### DIFF
--- a/asset.go
+++ b/asset.go
@@ -177,7 +177,7 @@ func (service *AssetsService) Get(spaceID, assetID string) (*Asset, error) {
 	return &asset, nil
 }
 
-// Get returns a single asset entity
+// GetLocalized returns a single asset entity. You need to specify the target locale you wish to retrieve.
 func (service *AssetsService) GetLocalized(spaceID, assetID string, local string) (*Asset, error) {
 	path := fmt.Sprintf("/spaces/%s/assets/%s", spaceID, assetID)
 	method := "GET"

--- a/asset.go
+++ b/asset.go
@@ -108,13 +108,19 @@ func (asset *Asset) UnmarshalJSON(data []byte) error {
 		}
 
 		asset.Fields = &FileFields{
-			Title:       title.(string),
-			Description: description.(string),
-			File:        &File{},
+			Title: title.(string),
+			File:  &File{},
+		}
+		if description != nil {
+			asset.Fields.Description = description.(string)
 		}
 
 		file := payload["fields"].(map[string]interface{})["file"].(map[string]interface{})[asset.locale]
-		if err := json.Unmarshal([]byte(file.(string)), asset.Fields.File); err != nil {
+		marshal, err := json.Marshal(file.(map[string]interface{}))
+		if err != nil {
+			return err
+		}
+		if err := json.Unmarshal(marshal, asset.Fields.File); err != nil {
 			return err
 		}
 	} else {
@@ -164,6 +170,24 @@ func (service *AssetsService) Get(spaceID, assetID string) (*Asset, error) {
 	}
 
 	var asset Asset
+	if err := service.c.do(req, &asset); err != nil {
+		return nil, err
+	}
+
+	return &asset, nil
+}
+
+// Get returns a single asset entity
+func (service *AssetsService) GetLocalized(spaceID, assetID string, local string) (*Asset, error) {
+	path := fmt.Sprintf("/spaces/%s/assets/%s", spaceID, assetID)
+	method := "GET"
+
+	req, err := service.c.newRequest(method, path, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	asset := Asset{locale: local}
 	if err := service.c.do(req, &asset); err != nil {
 		return nil, err
 	}

--- a/asset.go
+++ b/asset.go
@@ -178,7 +178,7 @@ func (service *AssetsService) Get(spaceID, assetID string) (*Asset, error) {
 }
 
 // GetLocalized returns a single asset entity. You need to specify the target locale you wish to retrieve.
-func (service *AssetsService) GetLocalized(spaceID, assetID string, local string) (*Asset, error) {
+func (service *AssetsService) GetLocalized(spaceID, assetID string, locale string) (*Asset, error) {
 	path := fmt.Sprintf("/spaces/%s/assets/%s", spaceID, assetID)
 	method := "GET"
 
@@ -187,7 +187,7 @@ func (service *AssetsService) GetLocalized(spaceID, assetID string, local string
 		return nil, err
 	}
 
-	asset := Asset{locale: local}
+	asset := Asset{locale: locale}
 	if err := service.c.do(req, &asset); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This should fix https://github.com/contentful-labs/contentful-go/issues/45

By specifying the target locale of an asset to retrieve we can correctly handle the data given by contentful.

Sample contentful data used to test this PR with:
```
{
  "metadata": {
    "tags": []
  },
  "sys": {
    "space": {
      "sys": {
        "type": "Link",
        "linkType": "Space",
        "id": "censored"
      }
    },
    "id": "censored",
    "type": "Asset",
    "createdAt": "2021-03-02T11:25:00.594Z",
    "updatedAt": "2021-03-02T11:28:53.219Z",
    "environment": {
      "sys": {
        "id": "master",
        "type": "Link",
        "linkType": "Environment"
      }
    },
    "publishedVersion": 2,
    "publishedAt": "2021-03-02T11:28:53.219Z",
    "firstPublishedAt": "2021-03-02T11:28:53.219Z",
    "createdBy": {
      "sys": {
        "type": "Link",
        "linkType": "User",
        "id": "censored"
      }
    },
    "updatedBy": {
      "sys": {
        "type": "Link",
        "linkType": "User",
        "id": "censored"
      }
    },
    "publishedCounter": 1,
    "version": 3,
    "publishedBy": {
      "sys": {
        "type": "Link",
        "linkType": "User",
        "id": "censored"
      }
    }
  },
  "fields": {
    "title": {
      "id-ID": "Article-12.2 01"
    },
    "file": {
      "id-ID": {
        "url": "//images.ctfassets.net/censored/censored/censored/Article-12.2_01.jpg",
        "details": {
          "size": 415255,
          "image": {
            "width": 1080,
            "height": 1920
          }
        },
        "fileName": "Article-12.2_01.jpg",
        "contentType": "image/jpeg"
      }
    }
  }
}
```